### PR TITLE
Fixed binary location in service unit file

### DIFF
--- a/systemd/rootgrow.service
+++ b/systemd/rootgrow.service
@@ -4,7 +4,7 @@ After=local-fs.target
 Wants=local-fs.target
 
 [Service]
-ExecStart=/usr/sbin/rootgrow
+ExecStart=/usr/bin/rootgrow
 Type=oneshot
 
 [Install]


### PR DESCRIPTION
rootgrow is installed via the console_scripts entrypoint
of pythons setuptools. Unfortunately that entrypoint does
not have an easy way to target a console script to /usr/sbin
which would be the correct location. As patching the situation
in setuptools will cause a huge chain of after effects for
a simple thing I decided to just go with /usr/bin and provide
this simple one liner patch in the systemd service file