### PR TITLE
Switch to use Popen instead of run

### DIFF
--- a/rootgrow/resizefs.py
+++ b/rootgrow/resizefs.py
@@ -21,19 +21,39 @@ import subprocess
 
 
 def get_mount_point(device):
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ['findmnt', '-n', '-f', '-o', 'TARGET', device],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
-    return result.stdout.strip().decode()
+    stdout_data, stderr_data = proc.communicate()
+    err_msg = stderr_data.decode()
+    if err_msg:
+        raise Exception(
+            'Unable to determine mount point for {1} {2}'.format(
+                device, err_msg
+            )
+    )
+    
+    return stdout_data.strip().decode()
 
 
 def get_mount_options(device):
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ['findmnt', '-n', '-f', '-o', 'OPTIONS', device],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
-    return result.stdout.decode().strip().split(',')
+    stdout_data, stderr_data = proc.communicate()
+    err_msg = stderr_data.decode()
+    if err_msg:
+        raise Exception(
+            'Unable to determine mount options for {1} {2}'.format(
+                device, err_msg
+            )
+    )
+    
+    return stdout_data.decode().strip().split(',')
 
 
 def resize_fs(fs_type, device):

--- a/rootgrow/resizefs.py
+++ b/rootgrow/resizefs.py
@@ -33,8 +33,7 @@ def get_mount_point(device):
             'Unable to determine mount point for {1} {2}'.format(
                 device, err_msg
             )
-    )
-    
+        )
     return stdout_data.strip().decode()
 
 
@@ -51,8 +50,7 @@ def get_mount_options(device):
             'Unable to determine mount options for {1} {2}'.format(
                 device, err_msg
             )
-    )
-    
+        )
     return stdout_data.decode().strip().split(',')
 
 

--- a/rootgrow/rootgrow.py
+++ b/rootgrow/rootgrow.py
@@ -34,7 +34,6 @@ def get_root_device():
         raise Exception(
             'Unable to determine root partition {}'.format(err_msg)
         )
-    
     return stdout_data.strip().decode()
 
 
@@ -51,7 +50,6 @@ def get_root_filesystem_type(root_device):
             'Unable to determine root filesystem on {1} {2}'.format(
                 root_device, err_msg)
         )
-    
     return stdout_data.strip().decode()
 
 
@@ -66,8 +64,9 @@ def get_disk_device_from_root(root_device):
     if err_msg:
         raise Exception(
             'Unable to determine root disk from {1} {2}'.format(
-                root_device, err_msg)
-    )
+                root_device, err_msg
+            )
+        )
     for device_info in stdout_data.decode().split(os.linesep):
         device_list = device_info.split()
         if device_list and device_list[1] == 'disk':
@@ -84,8 +83,10 @@ def get_partition_id_from_root(disk_device, root_device):
     err_msg = stderr_data.decode()
     if err_msg:
         raise Exception(
-            'Unable to determine root partition index {}'.format(err_msg)
-    )
+            'Unable to determine root partition index {}'.format(
+                err_msg
+            )
+        )
     partition_index = 0
     for device in stdout_data.decode().split(os.linesep):
         if device:

--- a/rootgrow/rootgrow.py
+++ b/rootgrow/rootgrow.py
@@ -23,39 +23,71 @@ from rootgrow.resizefs import resize_fs
 
 
 def get_root_device():
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ['findmnt', '-n', '-f', '-o', 'SOURCE', '/'],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
-    return result.stdout.strip().decode()
+    stdout_data, stderr_data = proc.communicate()
+    err_msg = stderr_data.decode()
+    if err_msg:
+        raise Exception(
+            'Unable to determine root partition {}'.format(err_msg)
+        )
+    
+    return stdout_data.strip().decode()
 
 
 def get_root_filesystem_type(root_device):
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ['blkid', '-s', 'TYPE', '-o', 'value', root_device],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
-    return result.stdout.strip().decode()
+    stdout_data, stderr_data = proc.communicate()
+    err_msg = stderr_data.decode()
+    if err_msg:
+        raise Exception(
+            'Unable to determine root filesystem on {1} {2}'.format(
+                root_device, err_msg)
+        )
+    
+    return stdout_data.strip().decode()
 
 
 def get_disk_device_from_root(root_device):
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ['lsblk', '-p', '-n', '-r', '-s', '-o', 'NAME,TYPE', root_device],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
-    for device_info in result.stdout.decode().split(os.linesep):
+    stdout_data, stderr_data = proc.communicate()
+    err_msg = stderr_data.decode()
+    if err_msg:
+        raise Exception(
+            'Unable to determine root disk from {1} {2}'.format(
+                root_device, err_msg)
+    )
+    for device_info in stdout_data.decode().split(os.linesep):
         device_list = device_info.split()
         if device_list and device_list[1] == 'disk':
             return device_list[0]
 
 
 def get_partition_id_from_root(disk_device, root_device):
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ['lsblk', '-p', '-n', '-r', '-o', 'NAME', disk_device],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    stdout_data, stderr_data = proc.communicate()
+    err_msg = stderr_data.decode()
+    if err_msg:
+        raise Exception(
+            'Unable to determine root partition index {}'.format(err_msg)
     )
     partition_index = 0
-    for device in result.stdout.decode().split(os.linesep):
+    for device in stdout_data.decode().split(os.linesep):
         if device:
             if device == root_device:
                 return partition_index

--- a/test/unit/resizefs_test.py
+++ b/test/unit/resizefs_test.py
@@ -1,5 +1,5 @@
 import unittest
-
+from pytest import raises
 from mock import (
     patch, Mock, call
 )
@@ -94,15 +94,15 @@ class TestResizeFs(unittest.TestCase):
     @patch('subprocess.Popen')
     def test_get_mount_point_error(self, mock_subprocess_popen):
         findmnt_mnt = Mock()
-        attrs = {'communicate.return_value': (b'', b'error')}
-        findmnt_mnt.configure_mock(**attrs)
-        with self.assertRaises(Exception) as context:
+        mock_subprocess_popen.return_value = findmnt_mnt
+        findmnt_mnt.communicate.return_value = (b'', b'error')
+        with raises(Exception):
             get_mount_point('/foo')
-   
+
     @patch('subprocess.Popen')
     def test_get_mount_options_error(self, mock_subprocess_popen):
         findmnt_mnt = Mock()
-        attrs = {'communicate.return_value': (b'', b'error')}
-        findmnt_mnt.configure_mock(**attrs)
-        with self.assertRaises(Exception) as context:
+        mock_subprocess_popen.return_value = findmnt_mnt
+        findmnt_mnt.communicate.return_value = (b'', b'error')
+        with raises(Exception):
             get_mount_options('/foo')

--- a/test/unit/resizefs_test.py
+++ b/test/unit/resizefs_test.py
@@ -1,11 +1,15 @@
+import unittest
+
 from mock import (
     patch, Mock, call
 )
 
-from rootgrow.resizefs import resize_fs
+from rootgrow.resizefs import (
+    get_mount_point, get_mount_options, resize_fs
+)
 
 
-class TestResizeFs(object):
+class TestResizeFs(unittest.TestCase):
     @patch('os.system')
     def test_resize_fs_ext(self, mock_os_system):
         resize_fs('ext3', '/dev/device')
@@ -14,34 +18,37 @@ class TestResizeFs(object):
         )
 
     @patch('os.system')
-    @patch('subprocess.run')
-    def test_resize_fs_xfs(self, mock_subprocess_run, mock_os_system):
+    @patch('subprocess.Popen')
+    def test_resize_fs_xfs(self, mock_subprocess_popen, mock_os_system):
         findmnt = Mock()
-        findmnt.stdout = b'/mount/point'
-        mock_subprocess_run.return_value = findmnt
+        attrs = {'communicate.return_value': (b'/mount/point', b'')}
+        findmnt.configure_mock(**attrs)
+        mock_subprocess_popen.return_value = findmnt
         resize_fs('xfs', '/dev/device')
-        mock_subprocess_run.assert_called_once_with(
-            ['findmnt', '-n', '-f', '-o', 'TARGET', '/dev/device'], stdout=-1
+        mock_subprocess_popen.assert_called_once_with(
+            ['findmnt', '-n', '-f', '-o', 'TARGET', '/dev/device'],
+            stdout=-1, stderr=-1
         )
         mock_os_system.assert_called_once_with(
             'xfs_growfs /mount/point'
         )
 
     @patch('os.system')
-    @patch('subprocess.run')
-    def test_resize_fs_btrfs(self, mock_subprocess_run, mock_os_system):
+    @patch('subprocess.Popen')
+    def test_resize_fs_btrfs(self, mock_subprocess_popen, mock_os_system):
         findmnt = Mock()
-        findmnt.stdout = b'/mount/point'
-        mock_subprocess_run.return_value = findmnt
+        attrs = {'communicate.return_value': (b'/mount/point', b'')}
+        findmnt.configure_mock(**attrs)
+        mock_subprocess_popen.return_value = findmnt
         resize_fs('btrfs', '/dev/device')
-        assert mock_subprocess_run.call_args_list == [
+        assert mock_subprocess_popen.call_args_list == [
             call(
                 ['findmnt', '-n', '-f', '-o', 'TARGET', '/dev/device'],
-                stdout=-1
+                stdout=-1, stderr=-1
             ),
             call(
                 ['findmnt', '-n', '-f', '-o', 'OPTIONS', '/dev/device'],
-                stdout=-1
+                stdout=-1, stderr=-1
             )
         ]
         mock_os_system.assert_called_once_with(
@@ -49,33 +56,53 @@ class TestResizeFs(object):
         )
 
     @patch('os.system')
-    @patch('subprocess.run')
+    @patch('subprocess.Popen')
     @patch('os.path.isdir')
     def test_resize_fs_btrfs_ro(
-        self, mock_os_path_isdir, mock_subprocess_run, mock_os_system
+        self, mock_os_path_isdir, mock_subprocess_popen, mock_os_system
     ):
         mock_os_path_isdir.return_value = True
         findmnt_mnt = Mock()
-        findmnt_mnt.stdout = b'/mount/point'
+        attrs = {'communicate.return_value': (b'/mount/point', b'')}
+        findmnt_mnt.configure_mock(**attrs)
         findmnt_opt = Mock()
-        findmnt_opt.stdout = b'ro,foo,bar'
-        mock_subprocess_run.side_effect = [findmnt_mnt, findmnt_opt]
+        attrs = {'communicate.return_value': (b'ro,foo,bar', b'')}
+        findmnt_opt.configure_mock(**attrs)
+        mock_subprocess_popen.side_effect = [findmnt_mnt, findmnt_opt]
         resize_fs('btrfs', '/dev/device')
         mock_os_system.assert_called_once_with(
             'btrfs filesystem resize max /mount/point/.snapshots'
         )
 
     @patch('os.system')
-    @patch('subprocess.run')
+    @patch('subprocess.Popen')
     @patch('os.path.isdir')
     def test_resize_fs_btrfs_ro_no_snapshots(
-        self, mock_os_path_isdir, mock_subprocess_run, mock_os_system
+        self, mock_os_path_isdir, mock_subprocess_popen, mock_os_system
     ):
         mock_os_path_isdir.return_value = False
         findmnt_mnt = Mock()
-        findmnt_mnt.stdout = b'/mount/point'
+        attrs = {'communicate.return_value': (b'/mount/point', b'')}
+        findmnt_mnt.configure_mock(**attrs)
         findmnt_opt = Mock()
-        findmnt_opt.stdout = b'ro,foo,bar'
-        mock_subprocess_run.side_effect = [findmnt_mnt, findmnt_opt]
+        attrs = {'communicate.return_value': (b'ro,foo,bar', b'')}
+        findmnt_opt.configure_mock(**attrs)
+        mock_subprocess_popen.side_effect = [findmnt_mnt, findmnt_opt]
         resize_fs('btrfs', '/dev/device')
         assert not mock_os_system.called
+
+    @patch('subprocess.Popen')
+    def test_get_mount_point_error(self, mock_subprocess_popen):
+        findmnt_mnt = Mock()
+        attrs = {'communicate.return_value': (b'', b'error')}
+        findmnt_mnt.configure_mock(**attrs)
+        with self.assertRaises(Exception) as context:
+            get_mount_point('/foo')
+   
+    @patch('subprocess.Popen')
+    def test_get_mount_options_error(self, mock_subprocess_popen):
+        findmnt_mnt = Mock()
+        attrs = {'communicate.return_value': (b'', b'error')}
+        findmnt_mnt.configure_mock(**attrs)
+        with self.assertRaises(Exception) as context:
+            get_mount_options('/foo')

--- a/test/unit/rootgrow_test.py
+++ b/test/unit/rootgrow_test.py
@@ -1,47 +1,57 @@
+import unittest
 import syslog
+
 from mock import (
     patch, Mock, call
 )
 
-from rootgrow.rootgrow import main
+from rootgrow.rootgrow import (
+    get_disk_device_from_root, get_partition_id_from_root, get_root_device,
+    get_root_filesystem_type, main
+)
 
 
-class TestRootGrow(object):
+class TestRootGrow(unittest.TestCase):
     @patch('os.system')
-    @patch('subprocess.run')
-    def test_rootgrow_main(self, mock_subprocess_run, mock_os_system):
+    @patch('subprocess.Popen')
+    def test_rootgrow_main(self, mock_subprocess_popen, mock_os_system):
         root_device = Mock()
-        root_device.stdout = b'/dev/sda3'
+        attrs = {'communicate.return_value': (b'/dev/sda3', b'')}
+        root_device.configure_mock(**attrs)
         root_fs = Mock()
-        root_fs.stdout = b'ext3'
+        attrs = {'communicate.return_value': (b'ext3', b'')}
+        root_fs.configure_mock(**attrs)
         root_disk = Mock()
-        root_disk.stdout = b'/dev/sda3 part\n/dev/sda disk'
+        attrs = {'communicate.return_value': (
+            b'/dev/sda3 part\n/dev/sda disk', b'')}
+        root_disk.configure_mock(**attrs)
         root_part = Mock()
-        root_part.stdout = \
-            b'/dev/sda\n/dev/sda1\n/dev/sda2\n/dev/sda3\n/dev/sda4'
-        mock_subprocess_run.side_effect = [
+        attrs = {'communicate.return_value': (
+            b'/dev/sda\n/dev/sda1\n/dev/sda2\n/dev/sda3\n/dev/sda4', b'')}
+        root_part.configure_mock(**attrs)
+        mock_subprocess_popen.side_effect = [
             root_device, root_fs, root_disk, root_part
         ]
         main()
-        assert mock_subprocess_run.call_args_list == [
+        assert mock_subprocess_popen.call_args_list == [
             call(
                 ['findmnt', '-n', '-f', '-o', 'SOURCE', '/'],
-                stdout=-1
+                stdout=-1, stderr=-1
             ),
             call(
                 ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/sda3'],
-                stdout=-1
+                stdout=-1, stderr=-1
             ),
             call(
                 [
                     'lsblk', '-p', '-n', '-r', '-s', '-o',
                     'NAME,TYPE', '/dev/sda3'
                 ],
-                stdout=-1
+                stdout=-1, stderr=-1
             ),
             call(
                 ['lsblk', '-p', '-n', '-r', '-o', 'NAME', '/dev/sda'],
-                stdout=-1
+                stdout=-1, stderr=-1
             )
         ]
         assert mock_os_system.call_args_list == [
@@ -49,11 +59,44 @@ class TestRootGrow(object):
             call('resize2fs /dev/sda3')
         ]
 
-    @patch('subprocess.run')
+    @patch('subprocess.Popen')
     @patch('syslog.syslog')
-    def test_rootgrow_main_raises(self, mock_syslog, mock_subprocess_run):
-        mock_subprocess_run.side_effect = Exception('error')
+    def test_rootgrow_main_raises(self, mock_syslog, mock_subprocess_popen):
+        mock_subprocess_popen.side_effect = Exception('error')
         main()
         mock_syslog.assert_called_once_with(
             syslog.LOG_ERR, 'rootgrow failed with: error'
         )
+
+
+    @patch('subprocess.Popen')
+    def test_get_root_device_error(self, mock_subprocess_popen):
+        findmnt_mnt = Mock()
+        attrs = {'communicate.return_value': (b'', b'error')}
+        findmnt_mnt.configure_mock(**attrs)
+        with self.assertRaises(Exception) as context:
+            get_root_device()
+
+    @patch('subprocess.Popen')
+    def test_get_root_filesystem_type_error(self, mock_subprocess_popen):
+        root_fs = Mock()
+        attrs = {'communicate.return_value': (b'', b'error')}
+        root_fs.configure_mock(**attrs)
+        with self.assertRaises(Exception) as context:
+            get_root_filesystem_type('/dev/foo')
+
+    @patch('subprocess.Popen')
+    def test_disk_device_from_root_error(self, mock_subprocess_popen):
+        device = Mock()
+        attrs = {'communicate.return_value': (b'', b'error')}
+        device.configure_mock(**attrs)
+        with self.assertRaises(Exception) as context:
+            get_disk_device_from_root('/dev/foo')
+
+    @patch('subprocess.Popen')
+    def test_get_partition_id_from_root_error(self, mock_subprocess_popen):
+        part_id = Mock()
+        attrs = {'communicate.return_value': (b'', b'error')}
+        part_id.configure_mock(**attrs)
+        with self.assertRaises(Exception) as context:
+            get_partition_id_from_root('/dev/foo', '/dev/foo1')


### PR DESCRIPTION
  + The run() fuction in the subprocess module was implemented after
    Python 3.4. However, we need to support Python 3.4 for SLES 12