### PR TITLE
- Change the logic to determine the partition ID of the root filesystem

### DIFF
--- a/package/rootgrow-spec-template
+++ b/package/rootgrow-spec-template
@@ -1,7 +1,7 @@
 #
 # spec file for package growpart-rootgrow
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/rootgrow/rootgrow.py
+++ b/rootgrow/rootgrow.py
@@ -90,12 +90,14 @@ def get_partition_id_from_root(disk_device, root_device):
                 err_msg
             )
         )
-    partition_index = 0
+    partition_index = ''
     for device in stdout_data.decode().split(os.linesep):
         if device:
             if device == root_device:
-                return partition_index
-            partition_index = partition_index + 1
+                for c in reversed(device):
+                    if c.isdigit():
+                        partition_index = c + partition_index
+                return int(partition_index)
 
 
 def main():

--- a/rootgrow/version.py
+++ b/rootgrow/version.py
@@ -18,4 +18,4 @@
 """
 Global version information used in rootgrow and the package
 """
-__VERSION__ = '1.0.3'
+__VERSION__ = '1.0.4'

--- a/test/unit/rootgrow_test.py
+++ b/test/unit/rootgrow_test.py
@@ -108,10 +108,10 @@ class TestRootGrow(unittest.TestCase):
         part_id = Mock()
         mock_subprocess_popen.return_value = part_id
         part_id.communicate.return_value = (
-            b'/dev/sda\n/dev/sda1',
+            b'/dev/sda\n/dev/sda1\n/dev/sda4\n/dev/sda10',
             b''
         )
-        assert get_partition_id_from_root('/dev/sda', '/dev/sda1') == 1
+        assert get_partition_id_from_root('/dev/sda', '/dev/sda10') == 10
         part_id.communicate.return_value = (
             b'', b'error'
         )


### PR DESCRIPTION
  + Previously the algorithm depended on the order of the output
    from lsblk using an index to keep track of the known partitions.
    The new implementation is order independent, it depends on the
    partition ID being numerical in nature and at the end of the device
    string.