### PR TITLE
Fix root partition ID lookup (bsc#1188868)

### DIFF
--- a/rootgrow/rootgrow.py
+++ b/rootgrow/rootgrow.py
@@ -97,7 +97,9 @@ def get_partition_id_from_root(disk_device, root_device):
                 for c in reversed(device):
                     if c.isdigit():
                         partition_index = c + partition_index
-                return int(partition_index)
+                    else:
+                        return int(partition_index)
+    raise Exception('Unable to determine root partition index')
 
 
 def main():

--- a/test/unit/rootgrow_test.py
+++ b/test/unit/rootgrow_test.py
@@ -117,3 +117,14 @@ class TestRootGrow(unittest.TestCase):
         )
         with raises(Exception):
             get_partition_id_from_root('/dev/sda', '/dev/sda1')
+
+    @patch('subprocess.Popen')
+    def test_get_partition_id_from_root_error2(self, mock_subprocess_popen):
+        part_id = Mock()
+        mock_subprocess_popen.return_value = part_id
+        part_id.communicate.return_value = (
+            b'/dev/sda\n/dev/foo\n',
+            b''
+        )
+        with raises(Exception):
+            get_partition_id_from_root('/dev/sda', '/dev/sda1')


### PR DESCRIPTION
Only consider trailing digits to be part of the paritition ID.