### PR TITLE
Support a btrfs filesystem being in a snapshot

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/rootgrow/rootgrow.py
+++ b/rootgrow/rootgrow.py
@@ -35,7 +35,8 @@ def get_root_device():
         raise Exception(
             'Unable to determine root partition {}'.format(err_msg)
         )
-    return stdout_data.strip().decode()
+    root_dev_path = stdout_data.strip().decode()
+    return root_dev_path.split('[')[0]
 
 
 def get_root_filesystem_type(root_device):

--- a/test/unit/rootgrow_test.py
+++ b/test/unit/rootgrow_test.py
@@ -115,6 +115,26 @@ class TestRootGrow(unittest.TestCase):
             get_root_device()
 
     @patch('subprocess.Popen')
+    def test_get_root_device_root_in_snap(self, mock_subprocess_popen):
+        findmnt_mnt = Mock()
+        mock_subprocess_popen.return_value = findmnt_mnt
+        findmnt_mnt.communicate.return_value = (
+            b'/dev/sda3[/@/.snapshots/1/snapshot]',
+            b''
+        )
+        assert get_root_device() == '/dev/sda3'
+
+    @patch('subprocess.Popen')
+    def test_get_root_device_root_on_part(self, mock_subprocess_popen):
+        findmnt_mnt = Mock()
+        mock_subprocess_popen.return_value = findmnt_mnt
+        findmnt_mnt.communicate.return_value = (
+            b'/dev/sda1',
+            b''
+        )
+        assert get_root_device() == '/dev/sda1'
+
+    @patch('subprocess.Popen')
     def test_get_root_filesystem_type_error(self, mock_subprocess_popen):
         root_fs = Mock()
         mock_subprocess_popen.return_value = root_fs


### PR DESCRIPTION
When the root of a btrfs filesystem is in a snapshot the findmnt command for the filesystem root (/) returns the snapshot information as well. However, we need to identify the device for purooses of growing the filesystem. Strip the snapshot information.